### PR TITLE
install dos2unix to make docker build compat with windows

### DIFF
--- a/Dockerfile_bleeding_edge
+++ b/Dockerfile_bleeding_edge
@@ -1,8 +1,14 @@
 FROM ubuntu:18.04
 MAINTAINER a_mma
 
+# get update
+RUN apt-get update; 
+
+# install compat windows/linux line endings
+RUN apt-get install -y dos2unix
+
 # install couchdb
-RUN apt-get update; apt-get install -y curl; apt-get install -y git
+RUN apt-get install -y curl; apt-get install -y git
 RUN echo "deb https://apache.bintray.com/couchdb-deb bionic main" \
     | tee -a /etc/apt/sources.list
 RUN apt-get install -y gnupg
@@ -41,5 +47,8 @@ RUN chmod +x /AquilaDB/src/init_aquila_db.sh
 
 # create DB data directory
 RUN mkdir /data
+
+# fix control characters between linux and windows
+RUN find /AquilaDB/src/ -type f -name "*.sh" -print0 | xargs -0 dos2unix
 
 CMD /AquilaDB/src/init_aquila_db.sh && tail -f /dev/null

--- a/Dockerfile_local_build
+++ b/Dockerfile_local_build
@@ -4,8 +4,14 @@ MAINTAINER a_mma
 # add <src> <dest>
 ADD . AquilaDB
 
-# install couchdb
-RUN apt-get update; apt-get install -y curl; apt-get install -y git
+# get update
+RUN apt-get update; 
+
+# install compat windows/linux line endings
+RUN apt-get install -y dos2unix
+
+# install git
+RUN apt-get install -y curl; apt-get install -y git
 
 # setup node environment
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
@@ -35,5 +41,8 @@ RUN chmod +x /AquilaDB/src/init_aquila_db.sh
 
 # create DB data directory
 RUN mkdir /data
+
+# fix control characters between linux and windows
+RUN find /AquilaDB/src/ -type f -name "*.sh" -print0 | xargs -0 dos2unix
 
 CMD /AquilaDB/src/init_aquila_db.sh && tail -f /dev/null

--- a/Dockerfile_stable_version
+++ b/Dockerfile_stable_version
@@ -1,8 +1,14 @@
 FROM ubuntu:18.04
 MAINTAINER a_mma
 
+# get update
+RUN apt-get update; 
+
+# install compat windows/linux line endings
+RUN apt-get install -y dos2unix
+
 # install couchdb
-RUN apt-get update; apt-get install -y curl; apt-get install -y git
+RUN apt-get install -y curl; apt-get install -y git
 RUN echo "deb https://apache.bintray.com/couchdb-deb bionic main" \
     | tee -a /etc/apt/sources.list
 RUN apt-get install -y gnupg
@@ -41,5 +47,8 @@ RUN chmod +x /AquilaDB/src/init_aquila_db.sh
 
 # create DB data directory
 RUN mkdir /data
+
+# fix control characters between linux and windows
+RUN find /AquilaDB/src/ -type f -name "*.sh" -print0 | xargs -0 dos2unix
 
 CMD /AquilaDB/src/init_aquila_db.sh && tail -f /dev/null


### PR DESCRIPTION
dos2unix formats line endings in for example bash scripts when written on Windows OS