### PR TITLE
added remote couch sync + local tested with IBM Cloudant

### DIFF
--- a/src/DB_config.yml
+++ b/src/DB_config.yml
@@ -18,5 +18,10 @@ couchDB:
   host: /data
   user: root
   password: 
+couchDBRemote:
+  DBInstance: default # database namespace
+  host:
+  user:
+  password: 
 vectorID:
   sync_t: 5000


### PR DESCRIPTION
Now it is possible to 
* use external CouchDB and its variants (ex. IBM Cloudant) as local document DB
* replicate to CouchDB and its variants (ex. IBM Cloudant) from local document DB - this will enable multiple AquilaDB instances sync through the network - this in turn enables sharding and data replication.